### PR TITLE
Bind Connector version to NSDb version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val `nsdb-kafka-connect` = (project in file("."))
     )
   )
   .settings(libraryDependencies ++= Dependencies.libraries)
+  .settings(libraryDependencies += Dependencies.nsdb.scalaAPI.value)
   .settings(
     resolvers in ThisBuild ++= Seq(
       "Radicalbit Public Releases" at "https://tools.radicalbit.io/artifactory/public-release/",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@
  */
 
 import sbt._
+import Keys._
 
 object Dependencies {
 
@@ -31,9 +32,8 @@ object Dependencies {
   }
 
   object nsdb {
-    lazy val version   = "1.0.0-SNAPSHOT"
     lazy val namespace = "io.radicalbit.nsdb"
-    lazy val scalaAPI  = namespace %% "nsdb-scala-api" % version
+    lazy val  scalaAPI = Def.setting { namespace %% "nsdb-scala-api" % (ThisBuild / version).value}
   }
 
   object scalatest {
@@ -44,7 +44,6 @@ object Dependencies {
 
   lazy val libraries = Seq(
     kafka.connect % Provided,
-    nsdb.scalaAPI,
     kcql.kcql,
     scalatest.core % Test
   )


### PR DESCRIPTION
This PR has the purpose to facilitate the connector version update by binding nsdb dependency version to this project version defined in the sbt build.
In this way, it will be enough to update the sbt version in order to update also the nsdb dependency;  furthermore, it will be mandatory to adopt the same version semantic and it will be sure that the version `X` of the connector is associated to the verison `X` of NSDb.

I'm not sure this is the most elegant solution, unfortunately, sbt doesn't allow to use `Task.value` outside its own DSL.
I also tried to use the build info plugin but the compiler links the `buildinfo` class after the classes inside the project folder, so it's not visible to the `Dependencies` class 