### PR TITLE
implement at least once semantic delivery

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,9 +42,18 @@ object Dependencies {
     lazy val core      = namespace %% "scalatest" % version
   }
 
+  object `cats-retry` {
+    lazy val version   = "0.3.1"
+    lazy val namespace = "com.github.cb372"
+    lazy val core      = namespace %% "cats-retry-core" % version
+    lazy val effect    = namespace %% "cats-retry-cats-effect" % version
+  }
+
   lazy val libraries = Seq(
     kafka.connect % Provided,
     kcql.kcql,
+    `cats-retry`.core,
+    `cats-retry`.effect,
     scalatest.core % Test
   )
 }

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkConnector.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkConnector.scala
@@ -86,6 +86,7 @@ class NSDbSinkConnector extends SinkConnector {
         taskConfigs.put(NSDbConfigs.NSDB_PORT, NSDbConfigs.NSDB_PORT_DEFAULT.toString)
         taskConfigs.put(NSDbConfigs.NSDB_SEMANTIC_DELIVERY, NSDbConfigs.NSDB_SEMANTIC_DELIVERY_DEFAULT)
         taskConfigs.put(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES, NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT.toString)
+        taskConfigs.put(NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP, NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP_DEFAULT.toString)
         taskConfigs.putAll(configProps)
         taskConfigs.put(NSDbConfigs.NSDB_KCQL, g.asScala.mkString(";")) //overwrite
         taskConfigs

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkConnector.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkConnector.scala
@@ -85,6 +85,7 @@ class NSDbSinkConnector extends SinkConnector {
         taskConfigs.put(NSDbConfigs.NSDB_HOST, NSDbConfigs.NSDB_HOST_DEFAULT)
         taskConfigs.put(NSDbConfigs.NSDB_PORT, NSDbConfigs.NSDB_PORT_DEFAULT.toString)
         taskConfigs.put(NSDbConfigs.NSDB_SEMANTIC_DELIVERY, NSDbConfigs.NSDB_SEMANTIC_DELIVERY_DEFAULT)
+        taskConfigs.put(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES, NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT.toString)
         taskConfigs.putAll(configProps)
         taskConfigs.put(NSDbConfigs.NSDB_KCQL, g.asScala.mkString(";")) //overwrite
         taskConfigs

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkConnector.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkConnector.scala
@@ -86,7 +86,8 @@ class NSDbSinkConnector extends SinkConnector {
         taskConfigs.put(NSDbConfigs.NSDB_PORT, NSDbConfigs.NSDB_PORT_DEFAULT.toString)
         taskConfigs.put(NSDbConfigs.NSDB_SEMANTIC_DELIVERY, NSDbConfigs.NSDB_SEMANTIC_DELIVERY_DEFAULT)
         taskConfigs.put(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES, NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT.toString)
-        taskConfigs.put(NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP, NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP_DEFAULT.toString)
+        taskConfigs.put(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRY_INTERVAL,
+                        NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRY_INTERVAL_DEFAULT.toString)
         taskConfigs.putAll(configProps)
         taskConfigs.put(NSDbConfigs.NSDB_KCQL, g.asScala.mkString(";")) //overwrite
         taskConfigs

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkTask.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkTask.scala
@@ -60,7 +60,8 @@ class NSDbSinkTask extends SinkTask {
         shardInterval =
           validateDuration(NSDbConfigs.NSDB_SHARD_INTERVAL, Option(props.get(NSDbConfigs.NSDB_SHARD_INTERVAL))),
         semanticDelivery =
-          validateSemanticDelivery(NSDbConfigs.NSDB_SEMANTIC_DELIVERY, props.get(NSDbConfigs.NSDB_SEMANTIC_DELIVERY))
+          validateSemanticDelivery(NSDbConfigs.NSDB_SEMANTIC_DELIVERY, props.get(NSDbConfigs.NSDB_SEMANTIC_DELIVERY)),
+        retries = Option(props.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES).toInt)
       ))
   }
 

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkTask.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkTask.scala
@@ -61,7 +61,9 @@ class NSDbSinkTask extends SinkTask {
           validateDuration(NSDbConfigs.NSDB_SHARD_INTERVAL, Option(props.get(NSDbConfigs.NSDB_SHARD_INTERVAL))),
         semanticDelivery =
           validateSemanticDelivery(NSDbConfigs.NSDB_SEMANTIC_DELIVERY, props.get(NSDbConfigs.NSDB_SEMANTIC_DELIVERY)),
-        retries = Option(props.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES).toInt)
+        retries = Option(props.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES).toInt),
+        sleep = validateDuration(NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP,
+                                 Option(props.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP)))
       ))
   }
 

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkTask.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkTask.scala
@@ -62,8 +62,8 @@ class NSDbSinkTask extends SinkTask {
         semanticDelivery =
           validateSemanticDelivery(NSDbConfigs.NSDB_SEMANTIC_DELIVERY, props.get(NSDbConfigs.NSDB_SEMANTIC_DELIVERY)),
         retries = Option(props.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES).toInt),
-        sleep = validateDuration(NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP,
-                                 Option(props.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP)))
+        sleep = validateDuration(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRY_INTERVAL,
+                                 Option(props.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRY_INTERVAL)))
       ))
   }
 

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkWriter.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkWriter.scala
@@ -170,7 +170,7 @@ object NSDbSinkWriter {
     val policy = RetryPolicies.limitRetries(maxRetries.getOrElse(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT) - 1)
 
     val finiteDurationSleep: FiniteDuration = {
-      val duration = sleep.getOrElse(Duration(NSDbConfigs.NSDB_AT_LEAST_ONCE_SLEEP_DEFAULT))
+      val duration = sleep.getOrElse(Duration(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRY_INTERVAL_DEFAULT))
       FiniteDuration(duration._1, duration._2)
     }
     def onFailure(throwable: Throwable, details: RetryDetails): Future[Unit] = {

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigs.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigs.scala
@@ -54,6 +54,10 @@ object NSDbConfigs {
   val NSDB_SEMANTIC_DELIVERY_DOC     = "NSDb semantic delivery (optional) [at_most_once (default), at_least_once]"
   val NSDB_SEMANTIC_DELIVERY_DEFAULT = Constants.AtMostOnce.value
 
+  val NSDB_AT_LEAST_ONCE_RETRIES         = "nsdb.at.least.once.retry"
+  val NSDB_AT_LEAST_ONCE_RETRIES_DOC     = "Number of writing retries when AT_LEAST_ONCE semantic is set"
+  val NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT = 3
+
   /**
     * @return sink expected configuration:
     *
@@ -129,5 +133,10 @@ object NSDbConfigs {
               NSDB_SEMANTIC_DELIVERY_DEFAULT,
               Importance.MEDIUM,
               NSDB_SEMANTIC_DELIVERY_DOC)
+      .define(NSDB_AT_LEAST_ONCE_RETRIES,
+              Type.INT,
+              NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT,
+              Importance.LOW,
+              NSDB_AT_LEAST_ONCE_RETRIES_DOC)
 
 }

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigs.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigs.scala
@@ -54,9 +54,13 @@ object NSDbConfigs {
   val NSDB_SEMANTIC_DELIVERY_DOC     = "NSDb semantic delivery (optional) [at_most_once (default), at_least_once]"
   val NSDB_SEMANTIC_DELIVERY_DEFAULT = Constants.AtMostOnce.value
 
-  val NSDB_AT_LEAST_ONCE_RETRIES         = "nsdb.at.least.once.retry"
+  val NSDB_AT_LEAST_ONCE_RETRIES         = "nsdb.at.least.once.retries"
   val NSDB_AT_LEAST_ONCE_RETRIES_DOC     = "Number of writing retries when AT_LEAST_ONCE semantic is set"
-  val NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT = 3
+  val NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT = 10
+
+  val NSDB_AT_LEAST_ONCE_SLEEP         = "nsdb.at.least.once.sleep"
+  val NSDB_AT_LEAST_ONCE_SLEEP_DOC     = "Time to sleep from a retry to anther when AT_LEAST_ONCE semantic is set"
+  val NSDB_AT_LEAST_ONCE_SLEEP_DEFAULT = "1500 milliseconds"
 
   /**
     * @return sink expected configuration:
@@ -138,5 +142,10 @@ object NSDbConfigs {
               NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT,
               Importance.LOW,
               NSDB_AT_LEAST_ONCE_RETRIES_DOC)
+      .define(NSDB_AT_LEAST_ONCE_SLEEP,
+              Type.STRING,
+              NSDB_AT_LEAST_ONCE_SLEEP_DEFAULT,
+              Importance.LOW,
+              NSDB_AT_LEAST_ONCE_SLEEP_DOC)
 
 }

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigs.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigs.scala
@@ -58,9 +58,9 @@ object NSDbConfigs {
   val NSDB_AT_LEAST_ONCE_RETRIES_DOC     = "Number of writing retries when AT_LEAST_ONCE semantic is set"
   val NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT = 10
 
-  val NSDB_AT_LEAST_ONCE_SLEEP         = "nsdb.at.least.once.sleep"
-  val NSDB_AT_LEAST_ONCE_SLEEP_DOC     = "Time to sleep from a retry to anther when AT_LEAST_ONCE semantic is set"
-  val NSDB_AT_LEAST_ONCE_SLEEP_DEFAULT = "1500 milliseconds"
+  val NSDB_AT_LEAST_ONCE_RETRY_INTERVAL         = "nsdb.at.least.once.sleep"
+  val NSDB_AT_LEAST_ONCE_RETRY_INTERVAL_DOC     = "Time to sleep from a retry to anther when AT_LEAST_ONCE semantic is set"
+  val NSDB_AT_LEAST_ONCE_RETRY_INTERVAL_DEFAULT = "500 milliseconds"
 
   /**
     * @return sink expected configuration:
@@ -142,10 +142,10 @@ object NSDbConfigs {
               NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT,
               Importance.LOW,
               NSDB_AT_LEAST_ONCE_RETRIES_DOC)
-      .define(NSDB_AT_LEAST_ONCE_SLEEP,
+      .define(NSDB_AT_LEAST_ONCE_RETRY_INTERVAL,
               Type.STRING,
-              NSDB_AT_LEAST_ONCE_SLEEP_DEFAULT,
+              NSDB_AT_LEAST_ONCE_RETRY_INTERVAL_DEFAULT,
               Importance.LOW,
-              NSDB_AT_LEAST_ONCE_SLEEP_DOC)
+              NSDB_AT_LEAST_ONCE_RETRY_INTERVAL_DOC)
 
 }

--- a/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkWriterSpec.scala
+++ b/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkWriterSpec.scala
@@ -324,7 +324,7 @@ class NSDbSinkWriterSpec extends FlatSpec with Matchers with OneInstancePerTest 
     }
 
     an[RuntimeException] shouldBe thrownBy(
-      NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None))
+      NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None, None))
   }
 
   "SinkRecordConversion" should "correctly return list of successfully result" in {
@@ -333,7 +333,7 @@ class NSDbSinkWriterSpec extends FlatSpec with Matchers with OneInstancePerTest 
     val result       = List(RPCInsertResult(completedSuccessfully = true), RPCInsertResult(completedSuccessfully = true))
     def futureResult = Future(result)
 
-    NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None) shouldBe result
+    NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None, None) shouldBe result
   }
 
   "SinkRecordConversion" should "thrown an Exception whether the future fails" in {
@@ -344,7 +344,7 @@ class NSDbSinkWriterSpec extends FlatSpec with Matchers with OneInstancePerTest 
     }
 
     an[RuntimeException] shouldBe thrownBy(
-      NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None))
+      NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None, None))
   }
 
   "SinkRecordConversion" should "validate semantic delivery according to the possible values" in {
@@ -395,6 +395,10 @@ class NSDbSinkWriterSpec extends FlatSpec with Matchers with OneInstancePerTest 
     Try {
       NSDbSinkWriter.validateDuration("testField", Some("2days"))
     } shouldBe Success(Some(Duration("2days")))
+
+    Try {
+      NSDbSinkWriter.validateDuration("testField", Some("1500 milliseconds"))
+    } shouldBe Success(Some(Duration("1500 milliseconds")))
   }
 
   "SinkRecordConversion" should "successfully convert records given a kcql without a value alias and a default value" in {

--- a/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkWriterSpec.scala
+++ b/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/NSDbSinkWriterSpec.scala
@@ -19,10 +19,12 @@ package io.radicalbit.nsdb.connector.kafka.sink
 import com.typesafe.scalalogging.{Logger, StrictLogging}
 import io.radicalbit.nsdb.api.scala.{Bit, Db}
 import io.radicalbit.nsdb.connector.kafka.sink.conf.Constants.AtLeastOnce
+import io.radicalbit.nsdb.rpc.response.RPCInsertResult
 import org.apache.kafka.connect.data._
 import org.apache.kafka.connect.sink.SinkRecord
 import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
 
+import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.{Success, Try}
 
@@ -309,6 +311,40 @@ class NSDbSinkWriterSpec extends FlatSpec with Matchers with OneInstancePerTest 
         .dimension("d1", "d1")
 
     bit shouldBe expectedBit
+  }
+
+  "SinkRecordConversion" should "thrown an Exception whether one of the result has 'completedSuccessfully' set to false" in {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    def futureResult = {
+      loggerImpl.info("Evaluating the future...")
+      Future(
+        List(RPCInsertResult(completedSuccessfully = true), RPCInsertResult(completedSuccessfully = false))
+      )
+    }
+
+    an[RuntimeException] shouldBe thrownBy(
+      NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None))
+  }
+
+  "SinkRecordConversion" should "correctly return list of successfully result" in {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val result       = List(RPCInsertResult(completedSuccessfully = true), RPCInsertResult(completedSuccessfully = true))
+    def futureResult = Future(result)
+
+    NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None) shouldBe result
+  }
+
+  "SinkRecordConversion" should "thrown an Exception whether the future fails" in {
+
+    def futureResult = {
+      loggerImpl.info("Evaluating the future...")
+      Future.failed[List[RPCInsertResult]](new RuntimeException("Any Reason Exception"))
+    }
+
+    an[RuntimeException] shouldBe thrownBy(
+      NSDbSinkWriter.writeWithDeliveryPolicy(Some(AtLeastOnce), futureResult, None))
   }
 
   "SinkRecordConversion" should "validate semantic delivery according to the possible values" in {

--- a/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigsSpec.scala
+++ b/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/NSDbConfigsSpec.scala
@@ -101,5 +101,15 @@ class NSDbConfigsSpec extends FlatSpec with Matchers with OneInstancePerTest {
     configKeys.get(NSDbConfigs.NSDB_SEMANTIC_DELIVERY).importance shouldBe Importance.MEDIUM
     configKeys.get(NSDbConfigs.NSDB_SEMANTIC_DELIVERY).documentation shouldBe NSDbConfigs.NSDB_SEMANTIC_DELIVERY_DOC
 
+    configKeys.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES).name shouldBe NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES
+    configKeys.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES).`type` shouldBe Type.INT
+    configKeys
+      .get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES)
+      .defaultValue shouldBe NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES_DEFAULT
+    configKeys.get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES).importance shouldBe Importance.LOW
+    configKeys
+      .get(NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES)
+      .documentation shouldBe NSDbConfigs.NSDB_AT_LEAST_ONCE_RETRIES_DOC
+
   }
 }


### PR DESCRIPTION
In this PR at least once semantic delivery has been implemented using the cats-retry library