### PR TITLE
Remove scala 2.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
-sudo: required
-dist: precise
 language: scala
 scala:
-  - 2.11.11
   - 2.12.7
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
-  - sbt clean coverage ++$TRAVIS_SCALA_VERSION fixCheck test coverageReport coverageAggregate
+  - sbt clean coverage fixCheck test coverageReport coverageAggregate
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - >
     test "${TRAVIS_PULL_REQUEST}" = 'false' &&
     test "${TRAVIS_REPO_SLUG}" = 'radicalbit/nsdb-kafka-connect' &&
-    test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' &&
     sh "$TRAVIS_BUILD_DIR/travis-credentials.sh" &&
     sbt ++$TRAVIS_SCALA_VERSION publish

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val `nsdb-kafka-connect` = (project in file("."))
     organization := "io.radicalbit.nsdb",
     name := "nsdb-kafka-connect",
     scalaVersion := "2.12.7",
-    crossScalaVersions := Seq("2.11.12", "2.12.7"),
+    crossPaths := false,
     scalacOptions := Seq(
       "-Ypartial-unification",
       "-Ywarn-unused",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,10 @@ object Dependencies {
 
   object nsdb {
     lazy val namespace = "io.radicalbit.nsdb"
-    lazy val  scalaAPI = Def.setting { namespace %% "nsdb-scala-api" % (ThisBuild / version).value}
+    lazy val  scalaAPI = Def.setting { namespace %% "nsdb-scala-api" % (ThisBuild / version).value excludeAll
+      (ExclusionRule(organization = "com.fasterxml.jackson.core"),
+        ExclusionRule(organization = "com.fasterxml.jackson.module"),
+        ExclusionRule(organization = "com.fasterxml.jackson.datatype"))}
   }
 
   object scalatest {


### PR DESCRIPTION
This PR aims to remove any trace of scala 2.11 from the project.

The reason is that it has been made the same operation on the parent project.

It is also made the library non cross path, so there is no longer required to explicitly specify scala version or use the double `%%` in sbt