### PR TITLE
allow empty string in configuration validation

### DIFF
--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/DottedNotationValidator.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/DottedNotationValidator.scala
@@ -27,7 +27,7 @@ object DottedNotationValidator extends ConfigDef.Validator {
 
   def ensureValid(name: String, value: Any): Unit = {
     Option(value).foreach { v =>
-      if (!v.toString.matches(dottedNotationList.regex))
+      if (!v.toString.isEmpty && !v.toString.matches(dottedNotationList.regex))
         throw new ConfigException(name, value, "Bad field format. Expected: [topicName.fieldName,topicName.fieldName]")
     }
   }

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/MappingConfUtility.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/MappingConfUtility.scala
@@ -130,9 +130,9 @@ trait MappingConfUtility {
 
     val (queryType, mappingsInterfaceAsString) =
       (kcqlConfig, metricsConfig) match {
-        case (Some(kcqlValue), _) if !kcqlValue.isEmpty =>
+        case (Some(kcqlValue), _) if kcqlValue.nonEmpty =>
           (Constants.KcqlType, kcqlValue.split(";").toList)
-        case (_, Some(metricsValue)) if !metricsValue.isEmpty =>
+        case (_, Some(metricsValue)) if metricsValue.nonEmpty =>
           val mappingsByTopic =
             parseMappings(
               metricsValue,

--- a/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/MappingConfUtility.scala
+++ b/src/main/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/MappingConfUtility.scala
@@ -130,9 +130,9 @@ trait MappingConfUtility {
 
     val (queryType, mappingsInterfaceAsString) =
       (kcqlConfig, metricsConfig) match {
-        case (Some(kcqlValue), _) =>
+        case (Some(kcqlValue), _) if !kcqlValue.isEmpty =>
           (Constants.KcqlType, kcqlValue.split(";").toList)
-        case (None, Some(metricsValue)) =>
+        case (_, Some(metricsValue)) if !metricsValue.isEmpty =>
           val mappingsByTopic =
             parseMappings(
               metricsValue,

--- a/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/DottedNotationValidatorSpec.scala
+++ b/src/test/scala/io/radicalbit/nsdb/connector/kafka/sink/conf/DottedNotationValidatorSpec.scala
@@ -25,8 +25,8 @@ class DottedNotationValidatorSpec extends FlatSpec with Matchers {
   "DottedNotationValidator" should "correctly validate null value" in {
     DottedNotationValidator.ensureValid(fieldName, null)
   }
-  "DottedNotationValidator" should "throw ConfigException for empty string value" in {
-    an[ConfigException] shouldBe thrownBy(DottedNotationValidator.ensureValid(fieldName, ""))
+  "DottedNotationValidator" should "correctly validate empty string value" in {
+    DottedNotationValidator.ensureValid(fieldName, "")
   }
   "DottedNotationValidator" should "throw ConfigException for invalid format value" in {
     an[ConfigException] shouldBe thrownBy(DottedNotationValidator.ensureValid(fieldName, "invalid-format"))
@@ -36,9 +36,6 @@ class DottedNotationValidatorSpec extends FlatSpec with Matchers {
   }
   "DottedNotationValidator" should "throw ConfigException for invalid format value 2" in {
     an[ConfigException] shouldBe thrownBy(DottedNotationValidator.ensureValid(fieldName, "valid.field,invalid-field"))
-  }
-  "DottedNotationValidator" should "throw ConfigException for invalid format value 3" in {
-    an[ConfigException] shouldBe thrownBy(DottedNotationValidator.ensureValid(fieldName, ""))
   }
   "DottedNotationValidator" should "throw ConfigException for invalid format value 4" in {
     DottedNotationValidator.ensureValid(fieldName, "-still_a.valid-format,_even.-this")


### PR DESCRIPTION
In this PR we allow empty string in configuration validation but we strengthen the control logic in the whole logic of the connector